### PR TITLE
feat(search): search via service and BehaviorSubject

### DIFF
--- a/src/app/components/header/header.component.html
+++ b/src/app/components/header/header.component.html
@@ -12,17 +12,18 @@
   <div class="p-toolbar-group-center">
   </div>
   <div class="p-toolbar-group-end">
-    <p-inputSwitch [(ngModel)]="checked" (click)="onThemeChange(checked ? 'dark' : 'light')"
-    id="theme-switch"/>
+    <p-inputSwitch [(ngModel)]="checked" (click)="onThemeChange(checked ? 'dark' : 'light')" id="theme-switch" />
   </div>
 </p-toolbar>
 
 <p-sidebar [(visible)]="sidebarVisible">
   <h3>Sidebar</h3>
-  <span class="p-input-icon-left">
-    <i class="pi pi-search"></i>
-    <input pInputText placeholder="Search" class="searchbox"/>
-  </span>
+  <div class="search">
+    <span class="p-input-icon-left">
+      <i class="pi pi-search"></i>
+      <input pInputText placeholder="Search" [(ngModel)]="searchTerm" (input)="onSearchTermChange(searchTerm)"/>
+    </span>
+  </div>
   <nav>
     <a routerLink="/about">About</a>
   </nav>

--- a/src/app/components/header/header.component.scss
+++ b/src/app/components/header/header.component.scss
@@ -29,7 +29,11 @@ nav {
   .logo {
     align-items: center;
   }
-  .searchbox{
+  .search {
     width:100%;
+
+    input {
+      width: 100%;
+    }
   }
 }

--- a/src/app/components/header/header.component.ts
+++ b/src/app/components/header/header.component.ts
@@ -8,6 +8,7 @@ import { InputTextModule } from "primeng/inputtext";
 import { SidebarModule } from 'primeng/sidebar';
 import { RouterLink } from "@angular/router";
 import { ThemeService } from "../../services/theme.service";
+import { DataService } from "../../services/data.service";
 
 @Component({
 	selector: "app-header",
@@ -28,10 +29,16 @@ export class HeaderComponent {
 	checked = true;
   sidebarVisible: boolean = false;
   selectedTheme: string = "dark";
+  searchTerm: string = "";
   themeService = inject(ThemeService);
+  dataService = inject(DataService);
 
   onThemeChange(theme: string): void {
 		this.selectedTheme = theme;
 		this.themeService.setTheme(theme);
 	}
+
+  onSearchTermChange(term: string): void {
+    this.dataService.setSearchTerm(term);
+  }
 }

--- a/src/app/services/data.service.ts
+++ b/src/app/services/data.service.ts
@@ -19,6 +19,5 @@ export class DataService {
 
   setSearchTerm(term: string) {
     this.searchTermSubject.next(term);
-    console.log('search term set to:', term);
   }
 }

--- a/src/app/services/data.service.ts
+++ b/src/app/services/data.service.ts
@@ -1,16 +1,24 @@
 import { HttpClient } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
 import { LGBTQTerm } from '../models/term';
+import { BehaviorSubject } from 'rxjs';
 
 @Injectable({
   providedIn: 'root'
 })
 export class DataService {
+  private searchTermSubject = new BehaviorSubject<string>('');
+  searchTerm$ = this.searchTermSubject.asObservable();
   http = inject(HttpClient);
 
   constructor() { }
 
-  getTerms() {
+  getAllTerms() {
     return this.http.get<LGBTQTerm[]>('/data/lgbtq-terms.json');
+  }
+
+  setSearchTerm(term: string) {
+    this.searchTermSubject.next(term);
+    console.log('search term set to:', term);
   }
 }


### PR DESCRIPTION
## This PR Closes Issue - Implementing Search Functionality
closes #2 

## Description

- I have kept the structure the same, the search input is still in the `header` sidebar and term cards are displayed in the `home` component
- since I already created a `data service` in the project I decided to implement the search functionality by adding a `searchTermSubject` behavior subject and a `searchTerm$` observable. This allows to pass along the search term typed in the input between components and use it for the filtering and displaying matching data via the `loadTerms` method in the `home` component.
- I did consider using signals and maybe in the future a signal could be implemented instead 

## What type of PR is this? (check all applicable)

- [x] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation
- [x] 👥 Core Team


## Mobile & Desktop Screenshots/Recordings
[Attach screenshots or recordings if applicable]

## Steps to QA

## [Optional] Post-deployment tasks
[Specify any post-deployment tasks that need to be performed]

## [Optional] What gif best describes this PR or how it makes you feel? 
[Embed gif or describe the feeling in plain text]
